### PR TITLE
Extend regex to match the new date header as well

### DIFF
--- a/src/igc.js
+++ b/src/igc.js
@@ -257,7 +257,7 @@
                 name: 'Logger serial number',
                 value: manufacturerInfo.serial
             });
-            var extractDate = infile.match(/H[FPO]DTE([\d]{6})/);
+            var extractDate = infile.match(/H[FPO]DTE(?:DATE:)?([\d]{6})/);
             if (extractDate) {
                 var dateRecord = extractDate[1];
             }


### PR DESCRIPTION
According to 'IGC FR Spec with AL4a' from 2016-04-10, the new date header entry is in format `HFDTEDATE:DDMMYY,NN`.
See http://www.fai.org/component/phocadownload/category/855-technicalspecifications?download=11005:igc-fr-spec-with-al4a-2016-4-10 page 23

 The regex will match the both formats, the old and the new.